### PR TITLE
fixes #8: pdftohtml not extracting text from some files

### DIFF
--- a/pdftohtml/HtmlOutputDev.cc
+++ b/pdftohtml/HtmlOutputDev.cc
@@ -428,7 +428,7 @@ void HtmlPage::coalesce(int pageNum) {
     addLineBreak = !noMerge && (fabs(str1->xMin - str2->xMin) < 0.4);
     vertSpace = str2->yMin - str1->yMax;
 
-//printf("coalesce %d %d %f? ", str1->dir, str2->dir, d);
+//printf("coalesce %d %d ? ", str1->dir, str2->dir);
 
     if (str2->yMin >= str1->yMin && str2->yMin <= str1->yMax)
     {
@@ -1109,6 +1109,8 @@ void HtmlOutputDev::drawChar(GfxState *state, double x, double y,
 	      CharCode code, int nBytes, Unicode *u, int uLen) 
 {
   if ( !showHidden && (state->getRender() & 3) == 3) {
+    // hack to render OCR text
+    pages->addChar(state, x, y, dx, dy, originX, originY, u, uLen);
     return;
   }
   pages->addChar(state, x, y, dx, dy, originX, originY, u, uLen);


### PR DESCRIPTION
fixes #8: not extracting text from some files

now extracts like so:

![image](https://cloud.githubusercontent.com/assets/22597962/20610830/52fea1b4-b254-11e6-8c6d-84b8abb85778.png)

from the original pdf (minor edit made to the original pdf from the github issue for testing purposes):
[433617.pdf](https://github.com/PolicyReporter/xpdf-pr/files/612257/433617.pdf)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/policyreporter/xpdf-pr/9)
<!-- Reviewable:end -->
